### PR TITLE
Feature: /teams and sundries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.crt
 *.key
+.idea/
+*.iml
 
 health-check-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM golang:1.17
 
-# copy server into container folder /go/src/go-server
-WORKDIR /go/src/go-server
+# copy server into container folder /go/src/github.com/eputnam/health-check-server
+WORKDIR /go/src/github.com/eputnam/health-check-server
 COPY . .
 
 # install dependencies and then install the module
 RUN go get -d -v ./...
 RUN go install -v ./...
 
-# expose 443 for https
-EXPOSE 443
+# expose 8080 for http
+EXPOSE 8080
 
 # start the server
-CMD ["go-server"]
+CMD ["health-check-server"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 TAG ?= latest
+APP ?= health-check-server
 
 .PHONY: docker
 
 server-build:
-	docker build . -t go-server:$(TAG) --progress=plain
+	docker build . -t $(APP):$(TAG) --progress=plain
 
 server-run:
-	docker run -it --rm -p 443:443 --name go-server go-server:$(TAG)
+	docker run -it --rm -p 8080:8080 --name $(APP) $(APP):$(TAG)
 
 db-run:
 	docker-compose up --detach db

--- a/api/server.go
+++ b/api/server.go
@@ -1,20 +1,26 @@
 package api
 
 import (
+	"github.com/eputnam/health-check-server/db"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 )
 
 type Server struct {
-	DB     *gorm.DB
+	DB     *db.DataStore
 	Router *gin.Engine
 }
 
-func NewServer(db *gorm.DB) *Server {
+func NewServer(db *db.DataStore) *Server {
 	server := &Server{DB: db}
 	router := gin.Default()
 
 	// router stuff
+	basePath := "/api"
+	v1Group := router.Group(basePath + "/v1")
+	{
+		v1Group.POST("/teams", server.CreateTeam)
+		v1Group.GET("/teams", server.GetTeams)
+	}
 
 	server.Router = router
 	return server

--- a/api/teams.go
+++ b/api/teams.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"github.com/eputnam/health-check-server/db"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type TeamAPI struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateTeamRequest struct {
+	Name string `json:"name"`
+}
+
+func (server *Server) CreateTeam(ginc *gin.Context) {
+	var request CreateTeamRequest
+	err := ginc.BindJSON(&request)
+	if nil != err {
+		ginc.JSON(http.StatusBadRequest, err)
+		panic(err)
+	}
+
+	newTeam := db.TeamDB{Name: request.Name}
+
+	team := server.DB.SaveTeam(newTeam)
+
+	ginc.JSON(http.StatusOK, &TeamAPI{Name: team.Name, ID: team.ID})
+}
+
+func (server *Server) GetTeams(ginc *gin.Context) {
+	teams := server.DB.GetTeams()
+	var apiTeams []TeamAPI
+	for _, v := range teams {
+		apiTeams = append(apiTeams, TeamAPI{Name: v.Name, ID: v.ID})
+	}
+	ginc.JSON(http.StatusOK, &apiTeams)
+}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,5 +1,18 @@
-# this is a sample config file. 
+# this is a sample config file
 # copy this file to "config.yaml" to use with the server
 server:
+  # host the server runs on. this is 0.0.0.0 for Docker reasons and it works fine outside of Docker, too
+  host: 0.0.0.0
   # port the server runs on
   port: 8080
+db:
+  # host the db runs on
+  host: localhost
+  # port the db runs on
+  port: 5432
+  # postgres user
+  user: postgres
+  # postgres password
+  password: crazytownbananapants
+  # name of the db for the server
+  dbname: healthcheck

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"gopkg.in/yaml.v2"
+	"os"
+)
+
+const config_path = "config.yaml"
+
+type GlobalConfig struct {
+	Server struct {
+		Host string `yaml:"host"`
+		Port string `yaml:"port"`
+	} `yaml:"server"`
+	DB struct {
+		Host     string `yaml:"host"`
+		Port     string `yaml:"port"`
+		User     string `yaml:"user"`
+		Password string `yaml:"password"`
+		DBName   string `yaml:"dbname"`
+	}
+}
+
+func LoadConfig() GlobalConfig {
+	file, err := os.Open(config_path)
+	checkError(err)
+	defer file.Close()
+
+	var config GlobalConfig
+	decoder := yaml.NewDecoder(file)
+	err = decoder.Decode(&config)
+	checkError(err)
+
+	return config
+}
+
+func checkError(err error) {
+	if nil != err {
+		panic(err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,9 @@ func LoadConfig() GlobalConfig {
 
 	var config GlobalConfig
 	decoder := yaml.NewDecoder(file)
-	err = decoder.Decode(&config)
-	checkError(err)
+	if err := decoder.Decode(&config); nil != err {
+		panic(err)
+	}
 
 	return config
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"fmt"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type SurveyDB struct {
+	gorm.Model
+	Team        string
+	ResponseURL string
+	Active      bool
+	EndTime     int64
+}
+
+func (SurveyDB) TableName() string {
+	return "surveys"
+}
+
+type ResponseDB struct {
+	gorm.Model
+	SurveyID   uint
+	QuestionID uint
+	Answer     int
+	UserID     string
+}
+
+func (ResponseDB) TableName() string {
+	return "responses"
+}
+
+type QuestionDB struct {
+	gorm.Model
+	Text     string
+	SurveyID uint
+}
+
+func (QuestionDB) TableName() string {
+	return "questions"
+}
+
+const (
+	host     = "localhost"
+	port     = 5432
+	user     = "postgres"
+	password = "crazytownbananapants"
+	dbname   = "postgres"
+)
+
+func NewDatabase() *gorm.DB {
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", host, port, user, password, dbname)
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if nil != err {
+		panic(err)
+	}
+
+	err = db.AutoMigrate(&SurveyDB{})
+	handleError(err)
+	err = db.AutoMigrate(&ResponseDB{})
+	handleError(err)
+	err = db.AutoMigrate(&QuestionDB{})
+	handleError(err)
+
+	return db
+}
+
+func handleError(err error) {
+	if nil != err {
+		panic(err)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -7,6 +7,10 @@ import (
 	"gorm.io/gorm"
 )
 
+type DataStore struct {
+	DB *gorm.DB
+}
+
 type SurveyDB struct {
 	gorm.Model
 	Team        string
@@ -41,6 +45,32 @@ func (QuestionDB) TableName() string {
 	return "questions"
 }
 
+type TeamDB struct {
+	gorm.Model
+	Name string
+}
+
+func (TeamDB) TableName() string {
+	return "teams"
+}
+
+func (ds *DataStore) SaveTeam(team TeamDB) TeamDB {
+	result := ds.DB.Create(&team)
+	if nil != result.Error {
+		panic(result.Error)
+	}
+	return team
+}
+
+func (ds *DataStore) GetTeams() []TeamDB {
+	var teams []TeamDB
+	result := ds.DB.Find(&teams, &TeamDB{})
+	if nil != result.Error {
+		panic(result.Error)
+	}
+	return teams
+}
+
 const (
 	host     = "localhost"
 	port     = 5432
@@ -49,7 +79,7 @@ const (
 	dbname   = "postgres"
 )
 
-func NewDatabase() *gorm.DB {
+func NewStore() *DataStore {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", host, port, user, password, dbname)
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if nil != err {
@@ -62,8 +92,10 @@ func NewDatabase() *gorm.DB {
 	handleError(err)
 	err = db.AutoMigrate(&QuestionDB{})
 	handleError(err)
+	err = db.AutoMigrate(&TeamDB{})
+	handleError(err)
 
-	return db
+	return &DataStore{DB: db}
 }
 
 func handleError(err error) {

--- a/db/db.go
+++ b/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"github.com/eputnam/health-check-server/config"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -71,16 +72,9 @@ func (ds *DataStore) GetTeams() []TeamDB {
 	return teams
 }
 
-const (
-	host     = "localhost"
-	port     = 5432
-	user     = "postgres"
-	password = "crazytownbananapants"
-	dbname   = "postgres"
-)
-
-func NewStore() *DataStore {
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", host, port, user, password, dbname)
+func NewStore(conf config.GlobalConfig) *DataStore {
+	dbConf := conf.DB
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", dbConf.Host, dbConf.Port, dbConf.User, dbConf.Password, dbConf.DBName)
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if nil != err {
 		panic(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,14 @@
 services:
+  server:
+    image: health-check-server:latest
+    ports:
+      - 8080:8080
+    depends_on:
+      - db
   db:
       image: postgres:14
       environment:
-        - POSTGRES_DB=postgres
+        - POSTGRES_DB=healthcheck
         - POSTGRES_USER=postgres
         - POSTGRES_PASSWORD=crazytownbananapants
       command: postgres -c max_connections=1500

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func main() {
-	db := db.NewDatabase()
-	server := api.NewServer(db)
+	store := db.NewStore()
+	server := api.NewServer(store)
 	server.StartServer("localhost:" + appConfig.Server.Port)
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,10 @@ func init() {
 }
 
 func main() {
-	store := db.NewStore(globalConfig)
+	store, err := db.NewStore(globalConfig)
+	if nil != err {
+		panic(err)
+	}
 	server := api.NewServer(store)
 	server.StartServer(globalConfig.Server.Host + ":" + globalConfig.Server.Port)
 }

--- a/main.go
+++ b/main.go
@@ -1,53 +1,19 @@
 package main
 
 import (
-	"os"
-
 	"github.com/eputnam/health-check-server/api"
+	"github.com/eputnam/health-check-server/config"
 	"github.com/eputnam/health-check-server/db"
-	"gopkg.in/yaml.v2"
 )
 
-const (
-	config_path = "config.yaml"
-)
-
-var appConfig AppConfig
-
-func checkError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
-/*
-CONFIG STUFF
-*/
-type AppConfig struct {
-	Server struct {
-		Port string `yaml:"port"`
-	} `yaml:"server"`
-}
-
-func loadConfig() AppConfig {
-	file, err := os.Open(config_path)
-	checkError(err)
-	defer file.Close()
-
-	var config AppConfig
-	decoder := yaml.NewDecoder(file)
-	err = decoder.Decode(&config)
-	checkError(err)
-
-	return config
-}
+var globalConfig config.GlobalConfig
 
 func init() {
-	appConfig = loadConfig()
+	globalConfig = config.LoadConfig()
 }
 
 func main() {
-	store := db.NewStore()
+	store := db.NewStore(globalConfig)
 	server := api.NewServer(store)
-	server.StartServer("localhost:" + appConfig.Server.Port)
+	server.StartServer(globalConfig.Server.Host + ":" + globalConfig.Server.Port)
 }

--- a/main.go
+++ b/main.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/eputnam/health-check-server/api"
+	"github.com/eputnam/health-check-server/db"
 	"gopkg.in/yaml.v2"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
 const (
@@ -16,69 +13,6 @@ const (
 )
 
 var appConfig AppConfig
-var db *gorm.DB
-
-/*
-DB STUFF
-*/
-
-const (
-	host     = "localhost"
-	port     = 5432
-	user     = "postgres"
-	password = "crazytownbananapants"
-	dbname   = "postgres"
-)
-
-type SurveyDB struct {
-	gorm.Model
-	Team        string
-	ResponseURL string
-	Active      bool
-	EndTime     time.Time
-}
-
-func (SurveyDB) TableName() string {
-	return "surveys"
-}
-
-type ResponseDB struct {
-	gorm.Model
-	SurveyID   uint
-	QuestionID uint
-	Answer     int
-	UserID     string
-}
-
-func (ResponseDB) TableName() string {
-	return "responses"
-}
-
-type QuestionDB struct {
-	gorm.Model
-	Text     string
-	SurveyID uint
-}
-
-func (QuestionDB) TableName() string {
-	return "questions"
-}
-
-func initializeDB() *gorm.DB {
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", host, port, user, password, dbname)
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	checkError(err)
-
-	db.AutoMigrate(&SurveyDB{})
-	db.AutoMigrate(&ResponseDB{})
-	db.AutoMigrate(&QuestionDB{})
-
-	return db
-}
-
-/*
-
- */
 
 func checkError(err error) {
 	if err != nil {
@@ -110,10 +44,10 @@ func loadConfig() AppConfig {
 
 func init() {
 	appConfig = loadConfig()
-	db = initializeDB()
 }
 
 func main() {
+	db := db.NewDatabase()
 	server := api.NewServer(db)
 	server.StartServer("localhost:" + appConfig.Server.Port)
 }


### PR DESCRIPTION
## Extract db from main.go

Currently, all the database stuff lives in main.go. Much like the server stuff, it's going to be easier in the long run to have the db stuff encapsulated in its own package. It'll be accessible to main.go AND the future api package. And its nice to have it all in one place, not a super controversial stance.

----
## Change db Database to DataStore

db was getting overloaded with GORM stuff, so, based on the tutorial i've referenced before, I called my type DataStore and it contains a DB, which is the gorm.DB.

----
## Add /teams GET and POST

Welcome to the new world order where you can now add a team to the database! This change sets up what I hope will be the convention going forward. API stuff will be stored in api/resource.go, endpoints are tracked in server.go, and db stuff in db/db.go. Error handling and logging could use a polish, but other than that I think this is a great start.

----
## Add IDEA stuff to gitignore

----
## Move config stuff out of main

This moves config stuff out of main.go and adds db stuff to the config file. Because encapsulation.

----
## Update Docker configs so it works again

All the Docker stuff has gotten a bit stale, this updates all that so the app can easily be run in Docker again. Yey.